### PR TITLE
chore(elasticsearch): Update result for new client

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -110,7 +110,7 @@ class Storage {
       suggest: {
         city_suggest: [{ options: cities } = { options: [] }],
       },
-    } = suggestions;
+    } = suggestions.body;
     return cities.map(({ _source: { country, region, city, timezone } }) => {
       return { country, region, city, timezone };
     });


### PR DESCRIPTION
Looks like the response may have changed, I tested this in a `node` repl in production and it seems to work. No location auto complete right now on profiles